### PR TITLE
Increase min width of preview iframe.

### DIFF
--- a/index.css
+++ b/index.css
@@ -100,6 +100,7 @@ h3 {
 #preview {
     max-height: 30px;
     border: none;
+    min-width: 350px;
 }
 
 #code {


### PR DESCRIPTION
Hi,
I noticed that the preview iframe is to small to display badges for the MV events. The issue occurred when using FireFox.
![example](https://i.imgur.com/1P0yvnU.png)
Sinze resizing cross-domaine iframes is pretty messy, I just increased the `min-width` of the iframe to fit the largest MV badge.